### PR TITLE
Refactor create algorithm to address issues #3 and #4

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,7 +583,7 @@ It constructs a new `did:cel` event log containing the [=DID document=] updated 
 the public key bound to an assertion method, and a [=data integrity proof=] for
 the document. This approach ensures that the [=DID=] is intrinsically
 bound to the document's initial state, providing strong integrity guarantees
-without requiring external registration. 
+without requiring external registration.
         </p>
 
         <p>
@@ -671,8 +671,8 @@ Set the `publicKeyMultibase` property of the |verificationMethod| to
               </ol>
             </li>
             <li>
-Create an initial `did:cel` [=DID document=] structure ([=map=] |didDocument|) with the
-following properties:
+Ensure the |didDocument| [=map=] is a valid initial `did:cel` [=DID document=] by 
+applying the following:
               <ol class="algorithm">
                 <li>
 The `@context` property value MUST be a [=list=] starting with two strings: 
@@ -723,7 +723,7 @@ controller will use to store the canonical version of the
                 </li>
               </ol>
             <li>
-Generate the [=DID=] by hashing the canonicalized [=DID document=]:
+Generate the `did:cel` identifier ([=DID=]) by hashing the canonicalized [=DID document=]:
               <ol class="algorithm">
                 <li>
 Canonicalize |didDocument| using JSON Canonicalization Scheme (JCS) as specified
@@ -748,26 +748,18 @@ Set the `controller` property of the |verificationMethod| to |didDocument|.`id`.
               </ol>
             </li>
             <li>
-Generate the |event| object by performing the following steps:
+Generate the |event| object by setting |event| to a [=map=] where the `operation` property is a [=map=] containing:
               <ol class="algorithm">
                 <li>
-Let |event| be a [=map=] containing an `operation` property.
+A `type` property with the value `create`.
                 </li>
                 <li>
-Set the `operation` property of |event| to a [=map=] containing:
-                  <ol class="algorithm">
-                    <li>
-A `type` property with the value `create`.
-                    </li>
-                    <li>
 A `data` property containing the |didDocument|.
-                    </li>
-                  </ol>
                 </li>
               </ol>
             </li>
             <li>
-Generate a cryptographic proof for |event| using a cryptosuite
+Generate a cryptographic proof for the |event| using a cryptosuite
 that is compatible with the generated |keyPair|, such as
 <a data-cite="VC-DI-ECDSA#ecdsa-jcs-2019">ecdsa-jcs-2019</a>:
               <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -671,8 +671,8 @@ Set the `publicKeyMultibase` property of the |verificationMethod| to
               </ol>
             </li>
             <li>
-Ensure the |didDocument| [=map=] is a valid genesis [=DID document=] by 
-applying the following:
+Verify that the |didDocument| [=map=] is a valid genesis [=DID document=] by 
+ensuring the following:
               <ol class="algorithm">
                 <li>
 The `@context` property value MUST be a [=list=] starting with two strings: 

--- a/index.html
+++ b/index.html
@@ -620,8 +620,8 @@ The following algorithm specifies how to create a new `did:cel` [=DID document=]
 with a new verification method and establish a cryptographic event
 log. The algorithm takes three parameters as input: a cryptographic |keyPair|,
 an optional [=map=] representing the initial |didDocument|,
-and |options|. The output is a [=map=] containing the completed `did:cel` |didDocument|, 
-the generated |verificationMethod|, and the initial |cryptographicEventLog|, or an error. 
+and |options|. If not an error, the output is a [=map=] containing the completed `did:cel`
+|didDocument|, the generated |verificationMethod|, and the initial |cryptographicEventLog|. 
 Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
           </p>
           <p>

--- a/index.html
+++ b/index.html
@@ -578,9 +578,9 @@ The following section outlines the DID operations for the `did:cel` method.
         <p>
 The create operation establishes a new `did:cel` [=DID document=] with a
 [=self-certifying identifier=] derived from the document's cryptographic hash. This
-operation accepts an initial cryptographic key pair and, optionally, an initial [=DID document=].
+operation accepts a cryptographic key pair and, optionally, an initial [=DID document=].
 It constructs a new `did:cel` event log containing the [=DID document=] updated with
-the public key as an assertion method, and a [=data integrity proof=] for
+the public key bound to an assertion method, and a [=data integrity proof=] for
 the document. This approach ensures that the [=DID=] is intrinsically
 bound to the document's initial state, providing strong integrity guarantees
 without requiring external registration. 
@@ -589,8 +589,9 @@ without requiring external registration.
         <p>
 Once the [=DID document=] is created and signed, a [=cryptographic event log=] (CEL) is
 initialized to track the complete history of operations on this DID. The log's
-first entry is a `create` event that contains the signed [=DID document=] as its
-data payload. This event serves as the cryptographic foundation for all
+first entry is a `create` event that contains the [=DID document=]
+as its data payload and a corresponding [=data integrity proof=].
+This event serves as the cryptographic foundation for all
 subsequent updates, enabling verifiable audit trails and [=witness=] attestation.
 The combination of the [=self-certifying identifier=], cryptographic proof, and
 event log creates a decentralized identifier implementation that requires no
@@ -598,8 +599,8 @@ centralized authority for creation, validation, or resolution.
         </p>
 
         <p>
-The `did:cel` event log identifier is bound to both the initial public key and 
-the initial [=DID document=] state inclusive of that public key.
+The `did:cel` event log identifier  is cryptographically bound to both the
+the public key and the initial [=DID document=] state, including that public key.
         </p>
 
         <p>
@@ -624,14 +625,14 @@ the generated |verificationMethod|, and the initial |cryptographicEventLog|, or 
 Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
           </p>
           <p>
-The initial |didDocument| may already contain defined relationship and services,
+The initial |didDocument| may already contain defined relationships and services,
 or it may be an empty [=map=].
           </p>
           <p>
-The |options| parameter is an optional [=map=] structure that allows to define a 
+The |options| parameter is an optional [=map=] structure that allows the definition of a
 |verificationMethod| identifier |options|.|vmId| and a boolean |options|.|referenced| flag, 
-wich defaults to `false`. This flag determines whether the |verificationMethod| is embedded directly in 
-`assertionMethod` or referenced through the [=DID document=]&rsquo;s `verificationMethod`. 
+which defaults to `false`. This flag determines whether the |verificationMethod| is embedded directly in 
+the `assertionMethod` or referenced through the [=DID document=]&rsquo;s `verificationMethod`. 
 If `options.vmId` is not set, a new identifier is generated automatically.
           </p>
 
@@ -640,8 +641,8 @@ If `options.vmId` is not set, a new identifier is generated automatically.
 Create an initial |verificationMethod| [=map=] structure.
               <ol class="algorithm">
                 <li>
-The |keyPair| algorithm MUST be supported by the <a data-cite="CID#Multikey">Multikey</a> specification.
-Otherwise, an error MUST be raised and SHOULD convey an error type of `UNSUPPORTED_KEY_TYPE`.
+If the |keyPair| algorithm is not supported by the <a data-cite="CID#Multikey">Multikey</a> specification, 
+then `UNSUPPORTED_KEY_TYPE` error has been detected and processing is aborted.
                 </li>
                 <li>
 Export the public key from |keyPair| as a <a
@@ -654,17 +655,17 @@ Let |verificationMethod| be a new empty [=map=].
 Set the `type` property of the |verificationMethod| to `Multikey`.
                 </li>
                 <li>
-If |options|.|vmId| is defined then set the `id` property of 
+If |options|.|vmId| is exists, then set the `id` property of 
 the |verificationMethod| to the concatenation of the `#` character 
 and the |vmId| value.
                 </li>
                 <li>
-Otherwise, set the `id` property to 
+Otherwise, set the `id` property of |verificationMethod| to 
 the concatenation of the `#`  character and the `publicKeyMultibase` 
 representation of the |publicKey|.
                 </li>
                 <li>
-Set the `publicKeyMultibase` property of the |verificationMethod|. to
+Set the `publicKeyMultibase` property of the |verificationMethod| to
 `publicKeyMultibase` representation of |publicKey|.
                 </li>
               </ol>
@@ -674,35 +675,38 @@ Create an initial `did:cel` [=DID document=] structure ([=map=] |didDocument|) w
 following properties:
               <ol class="algorithm">
                 <li>
-The `@context` property value MUST be an array starting with two string: 
+The `@context` property value MUST be a [=list=] starting with two strings: 
 `https://www.w3.org/ns/did/v1.1` and `https://w3id.org/didcel/v1`.
                   <ol class="algorithm">
                     <li>
 If the |didDocument| does not contain the `@context` property then set its value accordingly.
                     </li>
                     <li>
-Otherwise, if `@context` property value does not start with the manadory contexts above,
-an error MUST be raised and SHOULD convey an error type of `INVALID_CONTEXT`.
-                    </li>
-                  </ol>
-                </li>              
-                <li>
-The `heartbeatFrequency` property value MUST conform to ISO 8601 duration format.
-                  <ol class="algorithm">
-                    <li>
-If the |didDocument| does not contain the `heartbeatFrequency` property then set value to default `P3M`.
-                    </li>
-                    <li>
-Otherwise, if the `heartbeatFrequency` property value does not conform to ISO 8601 duration format,
-an error MUST be raised and SHOULD convey an error type of `INVALID_HEARTBEAT_FREQUENCY`.
+Otherwise, if the `@context` property value does not start with the mandatory contexts above
+then `INVALID_CONTEXT` error has been detected and processing is aborted.
                     </li>
                   </ol>
                 </li>
                 <li>
-An `assertionMethod` MUST be bound to the |verificationMethod|.
+Remove the `id` property from |didDocument| if it exists.
+                </li>             
+                <li>
+The `heartbeatFrequency` property value MUST conform to ISO 8601 duration format.
                   <ol class="algorithm">
                     <li>
-if |options|.|referenced| is `false`, then add the |verificationMethod| to 
+If the |didDocument| does not contain the `heartbeatFrequency` property then set its value to default `P3M`.
+                    </li>
+                    <li>
+Otherwise, if the `heartbeatFrequency` property value does not conform to ISO 8601 duration format
+then `INVALID_HEARTBEAT_FREQUENCY` error has been detected and processing is aborted.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+A |verificationMethod| MUST be bound to the `assertionMethod`.
+                  <ol class="algorithm">
+                    <li>
+If |options|.|referenced| is `false`, then add the |verificationMethod| to 
 |didDocument|.`assertionMethod` property.
                     </li>
                     <li>
@@ -712,7 +716,7 @@ and add |verificationMethod|.`id` to the |didDocument|.`assertionMethod` propert
                   </ol>
                 </li>
                 <li>
-Add a <a data-cite="CID#services">service entry</a> where the `type` is
+Add an entry to the `service` property of the |didDocument| where the `type` is
 `CelStorageService` and the `serviceEndpoint` is a list of URLs that the
 controller will use to store the canonical version of the
 [=cryptographic event log=].
@@ -747,10 +751,10 @@ Set the `controller` property of the |verificationMethod| to |didDocument|.`id`.
 Generate the |event| object by performing the following steps:
               <ol class="algorithm">
                 <li>
-The event object MUST contain a [=map=] with an `operation` property.
+Let |event| be a [=map=] containing an `operation` property.
                 </li>
                 <li>
-The `operation` [=map=] MUST contain:
+Set the `operation` property of |event| to a [=map=] containing:
                   <ol class="algorithm">
                     <li>
 A `type` property with the value `create`.
@@ -765,15 +769,31 @@ A `data` property containing the |didDocument|.
             <li>
 Generate a cryptographic proof for |event| using a cryptosuite
 that is compatible with the generated |keyPair|, such as
-<a data-cite="VC-DI-ECDSA#ecdsa-jcs-2019">ecdsa-jcs-2019</a>. Set the
-`proofPurpose` to `assertionMethod`. Add the `proof` to the |event|.
+<a data-cite="VC-DI-ECDSA#ecdsa-jcs-2019">ecdsa-jcs-2019</a>:
+              <ol class="algorithm">
+                <li>
+Let |proofOptions| be an empty [=map=].
+                </li>
+                <li>
+Set the `proofPurpose` property of |proofOptions| to `assertionMethod`.
+                </li>
+                <li>
+Set  the `verificationMethod` property of |proofOptions| to |verificationMethod|.id.
+                </li>
+                <li>
+Generate |proof| by passing |proofOptions| and |keyPair| as inputs to the signature suite sign method.
+                </li>
+              </ol>
+            </li>
+            <li>
+Add the |proof| to the `proof` property of the |event|.
             </li>
             <li>
 Create the initial [=cryptographic event log=]:
               <ol class="algorithm">
                 <li>
-Create a new [=map=] |cryptographicEventLog| with a `log` property
-set to an array containing the |event| object.
+Let |cryptographicEventLog| be a [=map=] containing a `log` property
+set to a [=list=] containing the |event| object.
                 </li>
               </ol>
             </li>
@@ -792,7 +812,6 @@ Return a [=map=] containing:
               </ol>
             </li>
           </ol>
-
         </section>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -683,7 +683,7 @@ If the |didDocument| does not contain the `@context` property then set its value
                     </li>
                     <li>
 Otherwise, if the `@context` property value does not start with the mandatory contexts above
-then `INVALID_CONTEXT` error has been detected and processing is aborted.
+then an `INVALID_CONTEXT` error MUST be raised and processing is aborted.
                     </li>
                   </ol>
                 </li>

--- a/index.html
+++ b/index.html
@@ -620,8 +620,8 @@ The following algorithm specifies how to create a new `did:cel` [=DID document=]
 with a new verification method and establish a cryptographic event
 log. The algorithm takes three parameters as input: a cryptographic |keyPair|,
 an optional [=map=] representing the initial |didDocument|,
-and |options|. If not an error, the output is a [=map=] containing the completed `did:cel`
-|didDocument|, the generated |verificationMethod|, and the initial |cryptographicEventLog|. 
+and |options|. The output is a [=map=] containing the completed `did:cel` |didDocument|, 
+the generated |verificationMethod|, and the initial |cryptographicEventLog|, or an error. 
 Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
           </p>
           <p>

--- a/index.html
+++ b/index.html
@@ -748,7 +748,7 @@ Set the `controller` property of the |verificationMethod| to |didDocument|.`id`.
               </ol>
             </li>
             <li>
-Generate the |event| object by setting |event| to a [=map=] where the `operation` property is a [=map=] containing:
+Create the |event| object by setting |event| to a [=map=] where the `operation` property is a [=map=] containing:
               <ol class="algorithm">
                 <li>
 A `type` property with the value `create`.
@@ -785,8 +785,15 @@ Add the |proof| to the `proof` property of the |event|.
 Create the initial [=cryptographic event log=]:
               <ol class="algorithm">
                 <li>
-Let |cryptographicEventLog| be a [=map=] containing a `log` property
-set to a [=list=] containing the |event| object.
+Let |cryptographicEventLog| be a new [=map=].
+                </li>
+                <li>
+Let |eventEntry| be a new [=map=] with `event` property
+set to |event|.
+                </li>
+                <li>
+Set `log` property of the |cryptographicEventLog| to a new 
+[=list=] containg the |eventEntry|.
                 </li>
               </ol>
             </li>

--- a/index.html
+++ b/index.html
@@ -773,12 +773,13 @@ Set the `proofPurpose` property of |proofOptions| to `assertionMethod`.
 Set  the `verificationMethod` property of |proofOptions| to |verificationMethod|.id.
                 </li>
                 <li>
-Generate |proof| by passing |proofOptions| and |keyPair| as inputs to the signature suite sign method.
+Generate |proof| by passing |event| (the document to sign), |proofOptions|,
+and |keyPair| as inputs to the signature suite sign method.
+                </li>
+                <li>
+Add the |proof| to the `proof` property of the |event|.
                 </li>
               </ol>
-            </li>
-            <li>
-Add the |proof| to the `proof` property of the |event|.
             </li>
             <li>
 Create the initial [=cryptographic event log=]:

--- a/index.html
+++ b/index.html
@@ -578,7 +578,7 @@ The following section outlines the DID operations for the `did:cel` method.
         <p>
 The create operation establishes a new `did:cel` [=DID document=] with a
 [=self-certifying identifier=] derived from the document's cryptographic hash. This
-operation accepts a cryptographic key pair and, optionally, an initial [=DID document=].
+operation accepts a cryptographic key pair and an OPTIONAL initial [=DID document=].
 It constructs a new `did:cel` event log containing the [=DID document=] updated with
 the public key bound to an assertion method, and a [=data integrity proof=] for
 the document. This approach ensures that the [=DID=] is intrinsically
@@ -600,7 +600,7 @@ centralized authority for creation, validation, or resolution.
 
         <p>
 The `did:cel` event log identifier  is cryptographically bound to both the
-the public key and the genesis [=DID document=], including that public key.
+the public key and the genesis [=DID document=], which includes that public key.
         </p>
 
         <p>
@@ -625,7 +625,7 @@ the generated |verificationMethod|, and the initial |cryptographicEventLog|, or 
 Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
           </p>
           <p>
-The initial |didDocument| can already contain defined relationships and services,
+The initial |didDocument| can contain previously defined relationships and services,
 or it can be an empty [=map=].
           </p>
           <p>
@@ -641,8 +641,9 @@ If |options|.|vmId| is not set, a new identifier is generated automatically.
 Create |verificationMethod| [=map=] structure for the assertion:
               <ol class="algorithm">
                 <li>
-If the |keyPair| algorithm is not supported by the <a data-cite="CID#Multikey">Multikey</a> specification, 
-then a `UNSUPPORTED_KEY_TYPE` error MUST be raised and processing is aborted.
+If the |keyPair| algorithm is not supported by the <a data-cite="CID#Multikey">Multikey</a>
+specification, then an `UNSUPPORTED_KEY_TYPE` error MUST be raised and processing MUST be aborted.
+
                 </li>
                 <li>
 Export the public key from |keyPair| as a <a
@@ -655,13 +656,13 @@ Let |verificationMethod| be a new empty [=map=].
 Set the `type` property of the |verificationMethod| to `Multikey`.
                 </li>
                 <li>
-If |options|.|vmId| is exists, then set the `id` property of 
+If |options|.|vmId| exists, then set the `id` property of 
 the |verificationMethod| to the concatenation of the `#` character 
 and the |vmId| value.
                 </li>
                 <li>
 Otherwise, set the `id` property of |verificationMethod| to 
-the concatenation of the `#`  character and the `publicKeyMultibase` 
+the concatenation of the `#` character and the `publicKeyMultibase` 
 representation of the |publicKey|.
                 </li>
                 <li>
@@ -672,18 +673,18 @@ Set the `publicKeyMultibase` property of the |verificationMethod| to
             </li>
             <li>
 Verify that the |didDocument| [=map=] is a valid genesis [=DID document=] by 
-ensuring the following:
+taking the following steps:
               <ol class="algorithm">
                 <li>
-The `@context` property value MUST be a [=list=] starting with two strings: 
+Confirm that the `@context` property value is a [=list=] starting with two strings: 
 `https://www.w3.org/ns/did/v1.1` and `https://w3id.org/didcel/v1`.
                   <ol class="algorithm">
                     <li>
 If the |didDocument| does not contain the `@context` property then set its value accordingly.
                     </li>
                     <li>
-Otherwise, if the `@context` property value does not start with the mandatory contexts above
-then an `INVALID_CONTEXT` error MUST be raised and processing is aborted.
+Otherwise, if the `@context` property value does not start with the mandatory contexts listed
+above, then an `INVALID_CONTEXT` error MUST be raised and processing MUST be aborted.
                     </li>
                   </ol>
                 </li>
@@ -691,23 +692,23 @@ then an `INVALID_CONTEXT` error MUST be raised and processing is aborted.
 Remove the `id` property from |didDocument| if it exists.
                 </li>             
                 <li>
-The `heartbeatFrequency` property value MUST conform to ISO 8601 duration format.
+Confirm that the `heartbeatFrequency` property value conforms to ISO 8601 duration format.
                   <ol class="algorithm">
                     <li>
-If the |didDocument| does not contain the `heartbeatFrequency` property then set 
+If the |didDocument| does not contain the `heartbeatFrequency` property, then set 
 its value to `P3M`.
                     </li>
                     <li>
-Otherwise, if the `heartbeatFrequency` property value does not conform to ISO 8601 duration format
-then `INVALID_HEARTBEAT_FREQUENCY` error has been detected and processing is aborted.
+Otherwise, if the `heartbeatFrequency` property value does not conform to ISO 8601 duration format,
+then `INVALID_HEARTBEAT_FREQUENCY` error MUST be raised and processing MUST be aborted.
                     </li>
                   </ol>
                 </li>
                 <li>
-A |verificationMethod| MUST be bound to the `assertionMethod`.
+Confirm that a |verificationMethod| is bound to the `assertionMethod`.
                   <ol class="algorithm">
                     <li>
-If |options|.|referenced| is `false`, then add the |verificationMethod| to 
+If |options|.|referenced| is `false`, then add the |verificationMethod| to the
 |didDocument|.`assertionMethod` property.
                     </li>
                     <li>

--- a/index.html
+++ b/index.html
@@ -642,7 +642,7 @@ Create |verificationMethod| [=map=] structure for the assertion:
               <ol class="algorithm">
                 <li>
 If the |keyPair| algorithm is not supported by the <a data-cite="CID#Multikey">Multikey</a> specification, 
-then `UNSUPPORTED_KEY_TYPE` error has been detected and processing is aborted.
+then a `UNSUPPORTED_KEY_TYPE` error MUST be raised and processing is aborted.
                 </li>
                 <li>
 Export the public key from |keyPair| as a <a

--- a/index.html
+++ b/index.html
@@ -625,8 +625,8 @@ the generated |verificationMethod|, and the initial |cryptographicEventLog|, or 
 Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
           </p>
           <p>
-The initial |didDocument| may already contain defined relationships and services,
-or it may be an empty [=map=].
+The initial |didDocument| can already contain defined relationships and services,
+or it can be an empty [=map=].
           </p>
           <p>
 The |options| parameter is an optional [=map=] structure that allows the definition of a

--- a/index.html
+++ b/index.html
@@ -578,11 +578,12 @@ The following section outlines the DID operations for the `did:cel` method.
         <p>
 The create operation establishes a new `did:cel` [=DID document=] with a
 [=self-certifying identifier=] derived from the document's cryptographic hash. This
-operation generates an initial cryptographic key pair, constructs a [=DID document=] containing
-the public key as an assertion method, and adds a [=data integrity proof=] to
+operation accepts an initial cryptographic key pair and, optionally, an initial [=DID document=].
+It constructs a new `did:cel` event log containing the [=DID document=] updated with
+the public key as an assertion method, and a [=data integrity proof=] for
 the document. This approach ensures that the [=DID=] is intrinsically
 bound to the document's initial state, providing strong integrity guarantees
-without requiring external registration.
+without requiring external registration. 
         </p>
 
         <p>
@@ -594,6 +595,11 @@ subsequent updates, enabling verifiable audit trails and [=witness=] attestation
 The combination of the [=self-certifying identifier=], cryptographic proof, and
 event log creates a decentralized identifier implementation that requires no
 centralized authority for creation, validation, or resolution.
+        </p>
+
+        <p>
+The `did:cel` event log identifier is bound to both the initial public key and 
+the initial [=DID document=] state inclusive of that public key.
         </p>
 
         <p>
@@ -609,64 +615,109 @@ An example of a [=cryptographic event log=] containing the creation event for a
           <h4>Document Creation Algorithm</h4>
 
           <p>
-The following algorithm specifies how to create a new `did:cel` DID
-document with an initial verification method and establish a cryptographic event
-log. The algorithm takes an optional [=map=] |options| as input. The |options|
-map MAY contain a |keyType| property specifying an cryptographic key type to use
-(defaults to `P-256`). Output is a [=map=] containing the generated
-|didDocument|, the associated |keyPair|, and the initial
-|cryptographicEventLog|, or an error. Whenever this algorithm encodes strings,
-it MUST use UTF-8 encoding.
+The following algorithm specifies how to create a new `did:cel` [=DID document=]
+with an initial verification method and establish a cryptographic event
+log. The algorithm takes three parameters as input: a cryptographic |keyPair|,
+an optional [=map=] representing the generic initial |didDocument|,
+and |options|. The output is a [=map=] containing the `did:cel` |didDocument|, 
+the generated |verificationMethod|, and the initial |cryptographicEventLog|, or an error. 
+Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
+          </p>
+          <p>
+The initial |didDocument| may already contain defined relationship and services,
+or it may be an empty [=map=].
+          </p>
+          <p>
+The |options| parameter is an optional [=map=] structure that allows to define a 
+|verificationMethod| identifier |options|.|vmId| and a boolean |options|.|referenced| flag, 
+wich defaults to `false`. This flag determines whether the |verificationMethod| is embedded directly in 
+`assertionMethod` or referenced through the [=DID document=]&rsquo;s `verificationMethod`. 
+If `options.vmId` is not set, a new identifier is generated automatically.
           </p>
 
           <ol class="algorithm">
             <li>
-Let |keyType| be set to |options|.|keyType| if present, otherwise set to
-`P-256`. The |keyType| value MUST be a valid keyType identifier
-supported by the <a data-cite="CID#Multikey">Multikey</a> specification.
-            </li>
-            <li>
-Generate a new key pair based on |keyType|. Let |keyPair| be the result. If key
-generation fails, an error MUST be raised and SHOULD convey an error type of
-`KEY_GENERATION_ERROR`.
-            </li>
-            <li>
+Create an initial |verificationMethod| [=map=] structure.
+              <ol class="algorithm">
+                <li>
+The |keyPair| algorithm MUST be supported by the <a data-cite="CID#Multikey">Multikey</a> specification.
+Otherwise, an error MUST be raised and SHOULD convey an error type of `UNSUPPORTED_KEY_TYPE`.
+                </li>
+                <li>
 Export the public key from |keyPair| as a <a
 data-cite="CID#Multikey">Multikey</a> value. Let |publicKey| be the result.
+                </li>
+                <li>
+Let |verificationMethod| be a new empty [=map=].
+                </li>
+                <li>
+Set the `type` property of the |verificationMethod| to `Multikey`.
+                </li>
+                <li>
+If |options|.|vmId| is defined then set the `id` property of 
+the |verificationMethod| to the concatenation of the `#` character 
+and the |vmId| value.
+                </li>
+                <li>
+Otherwise, set the `id` property to 
+the concatenation of the `#`  character and the `publicKeyMultibase` 
+representation of the |publicKey|.
+                </li>
+                <li>
+Set the `publicKeyMultibase` property of the |verificationMethod|. to
+`publicKeyMultibase` representation of |publicKey|.
+                </li>
+              </ol>
             </li>
             <li>
-Create an initial [=DID document=] structure ([=map=] |didDocument|) with the
+Create an initial `did:cel` [=DID document=] structure ([=map=] |didDocument|) with the
 following properties:
               <ol class="algorithm">
                 <li>
-Set |didDocument|.`@context` to an array containing the following
-two strings: `https://www.w3.org/ns/did/v1.1` and `https://w3id.org/didcel/v1`.
-                </li>
-                <li>
-Set |didDocument|.`assertionMethod` to an array containing a single
-verification method object with the following properties:
+The `@context` property value MUST be an array starting with two string: 
+`https://www.w3.org/ns/did/v1.1` and `https://w3id.org/didcel/v1`.
                   <ol class="algorithm">
                     <li>
-Set the verification method's `id` value to the concatenation of the
-`#` character and the `publicKeyMultibase` value of the |publicKey|.
+If the |didDocument| does not contain the `@context` property then set its value accordingly.
                     </li>
                     <li>
-Set the verification method's `type` to `Multikey`.
+Otherwise, if `@context` property value does not start with the manadory contexts above,
+an error MUST be raised and SHOULD convey an error type of `INVALID_CONTEXT`.
+                    </li>
+                  </ol>
+                </li>              
+                <li>
+The `heartbeatFrequency` property value MUST conform to ISO 8601 duration format.
+                  <ol class="algorithm">
+                    <li>
+If the |didDocument| does not contain the `heartbeatFrequency` property then set value to default `P3M`.
                     </li>
                     <li>
-Set the verification method's `publicKeyMultibase` to
-|publicKey|.`publicKeyMultibase`.
+Otherwise, if the `heartbeatFrequency` property value does not conform to ISO 8601 duration format,
+an error MUST be raised and SHOULD convey an error type of `INVALID_HEARTBEAT_FREQUENCY`.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+An `assertionMethod` MUST be bound to the |verificationMethod|.
+                  <ol class="algorithm">
+                    <li>
+if |options|.|referenced| is `false`, then add the |verificationMethod| to 
+|didDocument|.`assertionMethod` property.
                     </li>
                     <li>
+Otherwise, add the |verificationMethod| to the |didDocument|.`verificationMethod` property 
+and add |verificationMethod|.`id` to the |didDocument|.`assertionMethod` property.
+                    </li>
+                  </ol>
+                </li>
+                <li>
 Add a <a data-cite="CID#services">service entry</a> where the `type` is
 `CelStorageService` and the `serviceEndpoint` is a list of URLs that the
 controller will use to store the canonical version of the
 [=cryptographic event log=].
-                    </li>
-                  </ol>
                 </li>
               </ol>
-            </li>
             <li>
 Generate the [=DID=] by hashing the canonicalized [=DID document=]:
               <ol class="algorithm">
@@ -688,8 +739,7 @@ Set |didDocument|.`id` to the concatenated value of `did:cel:` and
 the |encodedHash|.
                 </li>
                 <li>
-Set the `controller` property of the verification method in
-|didDocument|.`assertionMethod` to |didDocument|.`id`.
+Set the `controller` property of the |verificationMethod| to |didDocument|.`id`.
                 </li>
               </ol>
             </li>
@@ -734,7 +784,7 @@ Return a [=map=] containing:
 |didDocument|: the completed [=DID document=] with the computed identifier
                 </li>
                 <li>
-|keyPair|: the generated key pair (including secret key material)
+|verificationMethod|: the generated verification method [=map=]
                 </li>
                 <li>
 |cryptographicEventLog|: the initial event log with the create event

--- a/index.html
+++ b/index.html
@@ -694,7 +694,8 @@ Remove the `id` property from |didDocument| if it exists.
 The `heartbeatFrequency` property value MUST conform to ISO 8601 duration format.
                   <ol class="algorithm">
                     <li>
-If the |didDocument| does not contain the `heartbeatFrequency` property then set its value to default `P3M`.
+If the |didDocument| does not contain the `heartbeatFrequency` property then set 
+its value to `P3M`.
                     </li>
                     <li>
 Otherwise, if the `heartbeatFrequency` property value does not conform to ISO 8601 duration format

--- a/index.html
+++ b/index.html
@@ -589,18 +589,18 @@ without requiring external registration.
         <p>
 Once the [=DID document=] is created and signed, a [=cryptographic event log=] (CEL) is
 initialized to track the complete history of operations on this DID. The log's
-first entry is a `create` event that contains the [=DID document=]
-as its data payload and a corresponding [=data integrity proof=].
-This event serves as the cryptographic foundation for all
+first recorded operation is a `create` event, that contains the [=DID document=]
+as its data payload along with a corresponding [=data integrity proof=].
+This event entry serves as the cryptographic foundation for all
 subsequent updates, enabling verifiable audit trails and [=witness=] attestation.
 The combination of the [=self-certifying identifier=], cryptographic proof, and
-event log creates a decentralized identifier implementation that requires no
+event log establishes a decentralized identifier implementation that requires no
 centralized authority for creation, validation, or resolution.
         </p>
 
         <p>
 The `did:cel` event log identifier  is cryptographically bound to both the
-the public key and the initial [=DID document=] state, including that public key.
+the public key and the genesis [=DID document=], including that public key.
         </p>
 
         <p>
@@ -617,10 +617,10 @@ An example of a [=cryptographic event log=] containing the creation event for a
 
           <p>
 The following algorithm specifies how to create a new `did:cel` [=DID document=]
-with an initial verification method and establish a cryptographic event
+with a new verification method and establish a cryptographic event
 log. The algorithm takes three parameters as input: a cryptographic |keyPair|,
-an optional [=map=] representing the generic initial |didDocument|,
-and |options|. The output is a [=map=] containing the `did:cel` |didDocument|, 
+an optional [=map=] representing the initial |didDocument|,
+and |options|. The output is a [=map=] containing the completed `did:cel` |didDocument|, 
 the generated |verificationMethod|, and the initial |cryptographicEventLog|, or an error. 
 Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
           </p>
@@ -633,12 +633,12 @@ The |options| parameter is an optional [=map=] structure that allows the definit
 |verificationMethod| identifier |options|.|vmId| and a boolean |options|.|referenced| flag, 
 which defaults to `false`. This flag determines whether the |verificationMethod| is embedded directly in 
 the `assertionMethod` or referenced through the [=DID document=]&rsquo;s `verificationMethod`. 
-If `options.vmId` is not set, a new identifier is generated automatically.
+If |options|.|vmId| is not set, a new identifier is generated automatically.
           </p>
 
           <ol class="algorithm">
             <li>
-Create an initial |verificationMethod| [=map=] structure.
+Create |verificationMethod| [=map=] structure for the assertion:
               <ol class="algorithm">
                 <li>
 If the |keyPair| algorithm is not supported by the <a data-cite="CID#Multikey">Multikey</a> specification, 
@@ -671,7 +671,7 @@ Set the `publicKeyMultibase` property of the |verificationMethod| to
               </ol>
             </li>
             <li>
-Ensure the |didDocument| [=map=] is a valid initial `did:cel` [=DID document=] by 
+Ensure the |didDocument| [=map=] is a valid genesis [=DID document=] by 
 applying the following:
               <ol class="algorithm">
                 <li>
@@ -748,7 +748,7 @@ Set the `controller` property of the |verificationMethod| to |didDocument|.`id`.
               </ol>
             </li>
             <li>
-Create the |event| object by setting |event| to a [=map=] where the `operation` property is a [=map=] containing:
+Create the |event| by setting |event| to a [=map=] where the `operation` property is a [=map=] containing:
               <ol class="algorithm">
                 <li>
 A `type` property with the value `create`.


### PR DESCRIPTION
This PR addresses issues #3 and #4. It allows passing a predefined DID document and an existing key pair to the algorithm, as well as defining a custom verification method ID. Feedback welcome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/filip26/did-cel-spec/pull/7.html" title="Last updated on Apr 30, 2026, 3:44 PM UTC (3f656e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-cel-spec/7/e4fb491...filip26:3f656e4.html" title="Last updated on Apr 30, 2026, 3:44 PM UTC (3f656e4)">Diff</a>