### PR TITLE
Add missing term definitions, event, event entry, genesis DID document 

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,6 +445,16 @@ approach creates an intrinsic binding between the identifier and its content
 without requiring external registration or validation.
           </dd>
 
+          <dt><dfn class="export" data-lt="storageEndpoint">storage endpoint</dfn></dt>
+          <dd>
+A location from which a [=cryptographic event log=] is retrieved. 
+A storage endpoint is identified by a URL and MUST resolve in
+[=cryptographic event log=] associated with a given `did:cel`
+identifier. Multiple storage endpoints SHOULD host identical copies of the same
+log, and implementations MUST treat them as interchangeable sources of data,
+relying on cryptographic verification rather than endpoint trust.
+          </dd>
+
           <dt><dfn class="export" data-lt="witnesses|witnessed|witnessing">witness</dfn></dt>
           <dd>
 An independent entity that provides cryptographic attestation to data in a

--- a/index.html
+++ b/index.html
@@ -421,9 +421,9 @@ pointed to has not been modified since the link was created.
 
           <dt><dfn class="export" data-lt="operation">operation</dfn></dt>
           <dd>
-A deterministic instruction describing how to derive or mutate
-a DID document. The operation is the core semantic content of
-an event.
+A deterministic state transition instruction that specifies how to
+update a DID Document and its lifecycle. The operation is 
+the core semantic content of an event and defines the intended state change.
           </dd>
 
           <dt><dfn class="export" data-lt="operationData">operation data</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@ of a series of transformation functions on the raw public key bytes:
       </p>
 
       <tt>
-did-cel-identifier := did:cel:MULTIBASE(base58-btc, MULTICODEC(sha3-256, JCS(initial-event-log-entry)))
+did-cel-identifier := did:cel:MULTIBASE(base58-btc, MULTIHASH(sha3-256, JCS(genesisDidDocument)))
       </tt>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -383,9 +383,33 @@ used throughout this specification.
 
           <dt><dfn class="export" data-lt="CEL">cryptographic event log</dfn></dt>
           <dd>
-A [=hashlinked=] chain of events that records the complete history of operations
-performed on a document with each event cryptographically tied to the
-preceding event.
+A [=hashlinked=] chain of events representing the complete set
+of state transitions and operations performed on a document,
+with each event cryptographically tied to the preceding event.
+The log is an append-only ordered collection preserving the
+sequence of recorded events.
+          </dd>
+
+          <dt><dfn class="export" data-lt="event">event</dfn></dt>
+          <dd>
+A self-contained object representing a single change of state
+or observable occurrence. An event records an operation in the
+cryptographic event log. Its integrity is asserted by the
+DID controller.
+          </dd>
+
+          <dt><dfn class="export" data-lt="eventEntry">event entry</dfn></dt>
+          <dd>
+A container object within a log that holds a single event. Its
+existence is cryptographically attested by oblivious
+witnesses.
+          </dd>
+
+          <dt><dfn class="export" data-lt="genesisDidDocument">genesis DID document</dfn>
+          <dd>
+The authoritative origin from which the `did:cel` identifier is generated and 
+which serves as the reference for inception verification. This original DID document is 
+the canonical basis of the identifier.
           </dd>
 
           <dt><dfn class="export" data-lt="hashlinked|hashlinking">hashlink</dfn></dt>
@@ -393,6 +417,25 @@ preceding event.
 A mechanism of connecting data through cryptographic hashes such that an
 observer can cryptographically verify that the contents of the data that is
 pointed to has not been modified since the link was created.
+          </dd>
+
+          <dt><dfn class="export" data-lt="operation">operation</dfn></dt>
+          <dd>
+A deterministic instruction describing how to derive or mutate
+a DID document. The operation is the core semantic content of
+an event.
+          </dd>
+
+          <dt><dfn class="export" data-lt="operationData">operation data</dfn></dt>
+          <dd>
+The payload of an operation containing the concrete document
+being created, updated, or otherwise affected.
+          </dd>
+
+          <dt><dfn class="export" data-lt="proof">proof</dfn></dt>
+          <dd>
+A cryptographic object associated with an event that provides
+integrity and authenticity guarantees for the event.
           </dd>
 
           <dt><dfn class="export">self-certifying identifier</dfn></dt>
@@ -411,7 +454,6 @@ attested to. Multiple <strong>witnesses</strong> can attest to the same data,
 and the process of creating such attestations is called
 <strong>witnessing</strong>.
           </dd>
-
         </dl>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -383,26 +383,26 @@ used throughout this specification.
 
           <dt><dfn class="export" data-lt="CEL">cryptographic event log</dfn></dt>
           <dd>
-A [=hashlinked=] chain of events representing the complete set
-of state transitions and operations performed on a document,
-with each event cryptographically tied to the preceding event.
+A [=hashlinked=] chain of [=events=] representing the complete set
+of state transitions and [=operations=] performed on a document,
+with each [=event=] cryptographically tied to the preceding [=event=].
 The log is an append-only ordered collection preserving the
-sequence of recorded events.
+sequence of recorded [=events=].
           </dd>
 
           <dt><dfn class="export" data-lt="event">event</dfn></dt>
           <dd>
 A self-contained object representing a single change of state
-or observable occurrence. An event records an operation in the
-cryptographic event log. Its integrity is asserted by the
+or observable occurrence. An event records an [=operation=] in the
+[=cryptographic event log=]. Its integrity is asserted by the
 DID controller.
           </dd>
 
           <dt><dfn class="export" data-lt="eventEntry">event entry</dfn></dt>
           <dd>
-A container object within a log that holds a single event. Its
+A container object within a log that holds a single [=event=]. Its
 existence is cryptographically attested by oblivious
-witnesses.
+[=witnesses=].
           </dd>
 
           <dt><dfn class="export" data-lt="genesisDidDocument">genesis DID document</dfn>
@@ -423,19 +423,19 @@ pointed to has not been modified since the link was created.
           <dd>
 A deterministic state transition instruction that specifies how to
 update a DID Document and its lifecycle. The operation is 
-the core semantic content of an event and defines the intended state change.
+the core semantic content of an [=event=] and defines the intended state change.
           </dd>
 
           <dt><dfn class="export" data-lt="operationData">operation data</dfn></dt>
           <dd>
-The payload of an operation containing the concrete document
+The payload of an [=operation=] containing the concrete document
 being created, updated, or otherwise affected.
           </dd>
 
           <dt><dfn class="export" data-lt="proof">proof</dfn></dt>
           <dd>
-A cryptographic object associated with an event that provides
-integrity and authenticity guarantees for the event.
+A cryptographic object associated with an [=event=] that provides
+integrity and authenticity guarantees for the [=event=].
           </dd>
 
           <dt><dfn class="export">self-certifying identifier</dfn></dt>


### PR DESCRIPTION
Adds initial definitions for terms like event, event entry, genesis DID document, etc. Many of these concepts belong in the CEL spec., adding it here to have a starting point.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/filip26/did-cel-spec/pull/10.html" title="Last updated on Apr 13, 2026, 4:26 PM UTC (03e4df2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/did-cel-spec/10/e4fb491...filip26:03e4df2.html" title="Last updated on Apr 13, 2026, 4:26 PM UTC (03e4df2)">Diff</a>